### PR TITLE
Revert "Bump jetty.version from 9.4.31.v20200723 to 11.0.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.37</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>


### PR DESCRIPTION
Reverts scunning-sps/spring21-sps-26#3

I cannot run the server after this merge. It seems like the one change done by the bot breaks the build.
![Screen Shot 2021-03-29 at 12 00 44 PM](https://user-images.githubusercontent.com/34457517/112879551-849f9380-9086-11eb-89c1-a42a8842c5b7.png)
