### PR TITLE
Get individual guide endpoint for the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,36 @@ The body of the response contains the guide that was just added.
     "content": string
 }
 ```
+
+### Guides: get
+Gets a guide.
+
+#### Request
+
+##### Http request
+
+| Method | Endpoint |
+| --- | --- |
+| `GET` | `/guides/{guideId}` |
+
+##### Parameters
+There are not any parameters for this method at the moment.
+
+##### Request Body
+No need to provide a body with this method.
+
+#### Response
+
+If the request succeeds, the server responds with an HTTP `200 OK`. 
+
+##### Response Body
+The body of the response contains the guide requested.
+```JSON
+{
+    "id": number,
+    "timestamp": number,
+    "title": string,
+    "description": string, 
+    "content": string
+}
+```

--- a/src/main/java/com/google/sps/data/Error.java
+++ b/src/main/java/com/google/sps/data/Error.java
@@ -1,0 +1,19 @@
+package com.google.sps.data;
+
+public class Error{
+    private final String errorMessage;
+    private final int code;
+
+    public Error(String message, int code){
+        this.errorMessage = message;
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -18,25 +18,29 @@ public class SpecificGuideServlet extends HttpServlet{
     static final long serialVersionUID = 0;
     private final DatastoreGuides helper = new DatastoreGuides();
     private final Gson gson = new Gson();
+    private long id;
 
-    private long getIdFromPath(String path){
+    private Optional<Error> getIdFromPath(String path){
         String[] parts = path.split("/");
-        return Long.parseLong(parts[1]);
+        try{
+            id = Long.parseLong(parts[1]);
+        }catch(RuntimeException exception){
+            return Optional.of(new Error("Guide id must be a number", 400));
+        }
+        return Optional.empty();
     }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
         response.setContentType("application/json");
 
-        long id;
-        try{
-            id = getIdFromPath(request.getPathInfo());
-        }catch(NumberFormatException exception){
+        Optional<Error> error = getIdFromPath(request.getPathInfo());
+        if(error.isPresent()){
             response.setStatus(400);
-            response.getWriter().print(gson.toJson(new Error("Guide id must be a number", 400)));
+            response.getWriter().print(gson.toJson(error.get()));
             return;
         }
-
+            
         Optional<Guide> guide = helper.get(id);
         
         if(!guide.isPresent()){

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -1,0 +1,37 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.Gson;
+import com.google.sps.data.Error;
+
+@WebServlet("/guides/*")
+public class SpecificGuideServlet extends HttpServlet{
+    static final long serialVersionUID = 0;
+    private final Gson gson = new Gson();
+
+    private long getIdFromPath(String path){
+        String[] parts = path.split("/");
+        return Long.parseLong(parts[1]);
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        long id;
+        try{
+            id = getIdFromPath(request.getPathInfo());
+        }catch(NumberFormatException exception){
+            response.setStatus(400);
+            response.getWriter().print(gson.toJson(new Error("Guide id must be a number", 400)));
+            return;
+        }
+
+        response.getWriter().println(id);
+
+    }
+}

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -1,6 +1,7 @@
 package com.google.sps.servlets;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -36,15 +37,15 @@ public class SpecificGuideServlet extends HttpServlet{
             return;
         }
 
-        Guide guide = helper.get(id);
-
-        if(guide == null){
+        Optional<Guide> guide = helper.get(id);
+        
+        if(!guide.isPresent()){
             response.setStatus(404);
             response.getWriter().print(gson.toJson(new Error("A guide with the specified id does not exist.", 404)));
             return;
         }
 
-        response.getWriter().println(gson.toJson(guide));
+        response.getWriter().println(gson.toJson(guide.get()));
 
     }
 }

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -18,26 +18,22 @@ public class SpecificGuideServlet extends HttpServlet{
     static final long serialVersionUID = 0;
     private final DatastoreGuides helper = new DatastoreGuides();
     private final Gson gson = new Gson();
-    private long id;
 
-    private Optional<Error> getIdFromPath(String path){
+    private long getIdFromPath(String path){
         String[] parts = path.split("/");
-        try{
-            id = Long.parseLong(parts[1]);
-        }catch(RuntimeException exception){
-            return Optional.of(new Error("Guide id must be a number", 400));
-        }
-        return Optional.empty();
+        return Long.parseLong(parts[1]);
     }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
         response.setContentType("application/json");
 
-        Optional<Error> error = getIdFromPath(request.getPathInfo());
-        if(error.isPresent()){
+        long id;
+        try{
+            id = getIdFromPath(request.getPathInfo());
+        }catch(NumberFormatException exeption){
             response.setStatus(400);
-            response.getWriter().print(gson.toJson(error.get()));
+            response.getWriter().print(gson.toJson(new Error("The guide id must be a number", 400)));
             return;
         }
             

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -9,10 +9,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.google.gson.Gson;
 import com.google.sps.data.Error;
+import com.google.sps.data.Guide;
+import com.google.sps.storage.DatastoreGuides;
 
 @WebServlet("/guides/*")
 public class SpecificGuideServlet extends HttpServlet{
     static final long serialVersionUID = 0;
+    private final DatastoreGuides helper = new DatastoreGuides();
     private final Gson gson = new Gson();
 
     private long getIdFromPath(String path){
@@ -31,7 +34,15 @@ public class SpecificGuideServlet extends HttpServlet{
             return;
         }
 
-        response.getWriter().println(id);
+        Guide guide = helper.get(id);
+
+        if(guide == null){
+            response.setStatus(404);
+            response.getWriter().print(gson.toJson(new Error("A guide with the specified id does not exist.", 404)));
+            return;
+        }
+
+        response.getWriter().println(gson.toJson(guide));
 
     }
 }

--- a/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/SpecificGuideServlet.java
@@ -25,6 +25,8 @@ public class SpecificGuideServlet extends HttpServlet{
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        response.setContentType("application/json");
+
         long id;
         try{
             id = getIdFromPath(request.getPathInfo());

--- a/src/main/java/com/google/sps/storage/DatastoreGuides.java
+++ b/src/main/java/com/google/sps/storage/DatastoreGuides.java
@@ -35,6 +35,8 @@ public class DatastoreGuides {
     }
 
     private Guide toGuide(Entity entity){
+        if (entity == null) return null;
+        
         long id = entity.getKey().getId();
         String title = entity.getString("title");
         String description = entity.getString("description");
@@ -60,5 +62,9 @@ public class DatastoreGuides {
 
     public List<Guide> queryAll(){
         return listFromQueryResults(datastore.run(query));
+    }
+
+    public Guide get(long id){
+        return toGuide(datastore.get(keyFactory.newKey(id)));
     }
 }

--- a/src/main/java/com/google/sps/storage/DatastoreGuides.java
+++ b/src/main/java/com/google/sps/storage/DatastoreGuides.java
@@ -2,6 +2,7 @@ package com.google.sps.storage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
@@ -35,8 +36,6 @@ public class DatastoreGuides {
     }
 
     private Guide toGuide(Entity entity){
-        if (entity == null) return null;
-        
         long id = entity.getKey().getId();
         String title = entity.getString("title");
         String description = entity.getString("description");
@@ -64,7 +63,12 @@ public class DatastoreGuides {
         return listFromQueryResults(datastore.run(query));
     }
 
-    public Guide get(long id){
-        return toGuide(datastore.get(keyFactory.newKey(id)));
+    public Optional<Guide> get(long id){
+        Entity entity = datastore.get(keyFactory.newKey(id));
+        if(entity == null){
+            return Optional.empty();
+        }
+
+        return Optional.of(toGuide(entity));
     }
 }

--- a/src/main/java/com/google/sps/storage/DatastoreGuides.java
+++ b/src/main/java/com/google/sps/storage/DatastoreGuides.java
@@ -65,10 +65,6 @@ public class DatastoreGuides {
 
     public Optional<Guide> get(long id){
         Entity entity = datastore.get(keyFactory.newKey(id));
-        if(entity == null){
-            return Optional.empty();
-        }
-
-        return Optional.of(toGuide(entity));
+        return Optional.ofNullable(entity).map(this::toGuide);
     }
 }


### PR DESCRIPTION
- Implements an endpoint to request a single guide using the `/guides/{guideId}` path.
- Implements a class to display errors as Json.
- Documents the endpoint.
- Adds a method in datastore helper to get a single guide.